### PR TITLE
Update token count hook entry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ src/
 │   ├── usePromptData.js        # CRUD + caching for prompts / categories
 │   ├── usePromptDump.js        # export DOCX / JSON hook
 │   ├── usePromptDump.test.js   # unit-test (if exists)
-│   ├── usePromptDump.js        # token count util (wrapper around gpt-3.5 est.)
+│   ├── useTokenCount.js        # token count util (wrapper around gpt-3.5 est.)
 │   └── useTokenCount.js        # fast tokenizer approximation
 ├── utils/
 │   ├── ChainModeToggle.jsx     # checkbox + <select> extracted from sidebar


### PR DESCRIPTION
## Summary
- fix duplicate hook name in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b55eeb8f0832cb2397a7d6935d0f3