### PR TITLE
Convert hooks and service to TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,20 +64,20 @@ src/
 │   └── DialogContext.jsx       # global confirm / alert dialog provider
 ├── hooks/
 │   ├── useAuth.js              # (WIP) higher-level auth helper
-│   ├── useIdleTimeout.js       # auto-logout after X minutes of inactivity
-│   ├── useProfile.js           # fetch + cache user profile row
+│   ├── useIdleTimeout.tsx      # auto-logout after X minutes of inactivity
+│   ├── useProfile.ts           # fetch + cache user profile row
 │   ├── usePromptData.js        # CRUD + caching for prompts / categories
 │   ├── usePromptDump.js        # export DOCX / JSON hook
 │   ├── usePromptDump.test.js   # unit-test (if exists)
-│   ├── useTokenCount.js        # token count util (wrapper around gpt-3.5 est.)
-│   └── useTokenCount.js        # fast tokenizer approximation
+│   ├── useTokenCount.ts        # token count util (wrapper around gpt-3.5 est.)
+│   └── useTokenCount.ts        # fast tokenizer approximation
 ├── utils/
 │   ├── ChainModeToggle.jsx     # checkbox + <select> extracted from sidebar
-│   ├── exportPrompts.js        # builds DOCX (sorted by category) or JSON
+│   ├── exportPrompts.tsx       # builds DOCX (sorted by category) or JSON
 │   ├── promptFilter.js         # client-side search / category / favorite filter
-│   ├── promptService.js        # Supabase service layer (CRUD helpers)
+│   ├── promptService.ts        # Supabase service layer (CRUD helpers)
 │   ├── promptService2.test.js  # edge-case unit-tests
-│   └── tokenCounter.js         # rough GPT token estimator (moved here)
+│   └── tokenCounter.ts         # rough GPT token estimator (moved here)
 ├── lib/
 │   └── inMemoryDb.js           # local mock repo (fallback without Supabase)
 ├── __tests__/                  # Vitest + RTL test suite

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' } }],
-    ['@babel/preset-react', { runtime: 'automatic' }]
+    ['@babel/preset-react', { runtime: 'automatic' }],
+    '@babel/preset-typescript'
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@babel/core": "^7.27.1",
         "@babel/preset-env": "^7.27.2",
         "@babel/preset-react": "^7.27.1",
+        "@babel/preset-typescript": "^7.21.5",
         "@tailwindcss/forms": "^0.5.10",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -1565,6 +1566,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
+      "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
@@ -1737,6 +1758,26 @@
         "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/plugin-transform-react-jsx-development": "^7.27.1",
         "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -10008,6 +10049,19 @@
         "@babel/helper-plugin-utils": "^7.27.1"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
+      "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      }
+    },
     "@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
@@ -10147,6 +10201,19 @@
         "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/plugin-transform-react-jsx-development": "^7.27.1",
         "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
       }
     },
     "@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/core": "^7.27.1",
     "@babel/preset-env": "^7.27.2",
     "@babel/preset-react": "^7.27.1",
+    "@babel/preset-typescript": "^7.21.5",
     "@tailwindcss/forms": "^0.5.10",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -2,9 +2,9 @@ import { useState, useEffect } from 'react';
 import { useSupabaseClient, useSession } from '@supabase/auth-helpers-react';
 
 export default function useProfile() {
-  const [profile, setProfile] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [profile, setProfile] = useState<any>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<any>(null);
 
   const session = useSession();
   const supabase = useSupabaseClient();
@@ -17,7 +17,7 @@ export default function useProfile() {
     }
   }, [session]);
 
-  const fetchProfile = async () => {
+  const fetchProfile = async (): Promise<void> => {
     setLoading(true);
     const { data, error } = await supabase
       .from('profiles')

--- a/src/hooks/useTokenCount.ts
+++ b/src/hooks/useTokenCount.ts
@@ -1,9 +1,9 @@
-// src/hooks/useTokenCount.js
+// src/hooks/useTokenCount.ts
 import { useEffect, useState } from 'react';
 import { tokensOf } from '../utils/tokenCounter';
 
-export default function useTokenCount(text, delay = 120) {
-  const [tokens, setTokens] = useState(() => tokensOf(text));
+export default function useTokenCount(text: string, delay: number = 120): number {
+  const [tokens, setTokens] = useState<number>(() => tokensOf(text));
 
   useEffect(() => {
     const handle = setTimeout(() => {

--- a/src/utils/promptService.ts
+++ b/src/utils/promptService.ts
@@ -1,8 +1,10 @@
 
-export const fetchCategories = (supabase) => 
+import { SupabaseClient } from '@supabase/supabase-js';
+
+export const fetchCategories = (supabase: SupabaseClient) =>
   supabase.from('categories').select('*');
 
-export const fetchPrompts = (supabase) =>
+export const fetchPrompts = (supabase: SupabaseClient) =>
   supabase
     .from('prompts')
     .select(`
@@ -14,7 +16,11 @@ export const fetchPrompts = (supabase) =>
     `)
     .order('sort_order', { ascending: true });
 
-export const savePrompt = async (supabase, prompt, userId) => {
+export const savePrompt = async (
+  supabase: SupabaseClient,
+  prompt: any,
+  userId: string,
+): Promise<any> => {
   const { categories, profiles, next_prompt, ...cleanPrompt } = prompt;
 
   const { error } = await supabase.from('prompts').upsert({
@@ -26,12 +32,16 @@ export const savePrompt = async (supabase, prompt, userId) => {
   return error;
 };
 
-export const deletePrompt = async (supabase, id) => {
+export const deletePrompt = async (supabase: SupabaseClient, id: string) => {
   const { error } = await supabase.from('prompts').delete().eq('id', id);
   return error;
 };
 
-export const clonePrompt = async (supabase, prompt, userId) => {
+export const clonePrompt = async (
+  supabase: SupabaseClient,
+  prompt: any,
+  userId: string,
+): Promise<any> => {
   const clonedPrompt = {
     title: `${prompt.title} (clone)`,
     content: prompt.content,
@@ -48,7 +58,11 @@ export const clonePrompt = async (supabase, prompt, userId) => {
   return error;
 };
 
-export const toggleFavorit = async (supabase, prompt, userId) => {
+export const toggleFavorit = async (
+  supabase: SupabaseClient,
+  prompt: any,
+  userId: string,
+): Promise<{ error: string | null }> => {
   if (!prompt.favorit) {
     const { data, error } = await supabase.rpc('set_favorite_with_limit', {
       prompt_id: prompt.id,
@@ -66,7 +80,10 @@ export const toggleFavorit = async (supabase, prompt, userId) => {
   return { error: null };
 };
 
-export const updatePromptOrder = async (supabase, reorderedPrompts) => {
+export const updatePromptOrder = async (
+  supabase: SupabaseClient,
+  reorderedPrompts: any[],
+) => {
   const updates = reorderedPrompts.map((prompt, index) =>
     supabase
       .from('prompts')


### PR DESCRIPTION
## Summary
- migrate `useProfile`, `useTokenCount` and `promptService` to TypeScript
- update README to reflect new file extensions
- enable TypeScript support in Babel and add preset dependency

## Testing
- `npm run test` *(fails: toggleFavorit and PromptCard expectations, and PromptFormModal fails to parse supabaseClient.js via import.meta)*

------
https://chatgpt.com/codex/tasks/task_e_684b59e3d9bc832c8625b077db8605c4