### PR TITLE
Implement chain view hover animation

### DIFF
--- a/src/components/PromptCard.css
+++ b/src/components/PromptCard.css
@@ -154,9 +154,9 @@
 /* --- chain-view badge ------------------------------------------------------- */
 .chain-order-badge {
   position: absolute;
-  top: 8px;  
+  top: 8px;
   right: 8px;
-  width: 28px;   
+  width: 28px;
   height: 28px;
   display: flex;
   align-items: center;
@@ -164,10 +164,27 @@
   font-size: 0.85rem;
   font-weight: 700;
 
-  background: rgba(255,255,255,0.16);   
+  background: rgba(255,255,255,0.16);
   color: #fff;
   backdrop-filter: blur(4px);
 
   border-radius: 6px;
   box-shadow: 0 1px 4px rgba(0,0,0,0.35);
+}
+
+/* --- chain hover line ------------------------------------------------------ */
+.chain-hover-line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -14px;
+  height: 2px;
+  background-image: repeating-linear-gradient(90deg, #fff, #fff 6px, transparent 6px, transparent 12px);
+  animation: chain-dash 0.6s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes chain-dash {
+  from { background-position: 0 0; }
+  to   { background-position: 12px 0; }
 }

--- a/src/components/PromptCard.jsx
+++ b/src/components/PromptCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { tokensOf } from '../utils/tokenCounter';
 import { useDialog } from '../context/DialogContext';
 import './PromptCard.css';
@@ -23,10 +23,16 @@ export default function PromptCard({
 
   const [color, setColor] = useState(prompt.color || 'default');
   const [copied, setCopied] = useState(false);
+  const [showLine, setShowLine] = useState(false);
+  const lineTimer = useRef(null);
 
   useEffect(() => {
     setColor(prompt.color || 'default');
   }, [prompt.color]);
+
+  useEffect(() => {
+    return () => clearTimeout(lineTimer.current);
+  }, []);
 
   const handleColorSelect = async (e, clr) => {
     e.stopPropagation();
@@ -65,12 +71,20 @@ export default function PromptCard({
     onToggleFavorit(prompt);
   };
 
+  const handleMouseEnter = () => {
+    if (!chainViewActive) return;
+    clearTimeout(lineTimer.current);
+    setShowLine(true);
+    lineTimer.current = setTimeout(() => setShowLine(false), 3000);
+  };
+
   return (
     <div
       className="prompt-card relative"      /* relative ⇒ badge pozícionálás */
       style={{ background: bgMap[color] }}
       tabIndex={-1}
       onFocus={(e) => e.currentTarget.blur()}
+      onMouseEnter={handleMouseEnter}
     >
       {/* 🔗 chain-badge only in chain-view */}
       {chainViewActive && prompt.chain_order != null && (
@@ -134,6 +148,7 @@ export default function PromptCard({
           </button>
         )}
       </div>
+      {showLine && <div className="chain-hover-line" />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- animate dashed connector when hovering a prompt in chain mode

## Testing
- `npm test` *(fails: toggleFavorit and PromptCard tests, plus Jest parse error)*

------
https://chatgpt.com/codex/tasks/task_e_684b5f64a450832cb74abf47906bb0e8