### PR TITLE
Persist selected chain filter

### DIFF
--- a/src/PromptApp.jsx
+++ b/src/PromptApp.jsx
@@ -26,10 +26,19 @@ export default function PromptApp() {
   const [favoriteOnly, setFavoriteOnly] = useState(false);
 
   const [chainView, setChainView] = useState(false);
-  const [chainFilter, setChainFilter] = useState('');
+  const [chainFilter, setChainFilter] = useState(() => {
+    if (typeof sessionStorage === 'undefined') return '';
+    return sessionStorage.getItem('chainFilter') || '';
+  });
   const [currentChain, setCurrentChain] = useState([]);
   const [chains, setChains] = useState([]);
   const [showWelcome, setShowWelcome] = useState(false);
+
+  useEffect(() => {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('chainFilter', chainFilter);
+    }
+  }, [chainFilter]);
 
   const {
     prompts, categories, handleSave, handleDelete,
@@ -149,7 +158,6 @@ export default function PromptApp() {
         chainViewActive={chainView && chainFilter !== ''}
         deactivateChainView={() => {
           setChainView(false);
-          setChainFilter('');
         }}
       />
 

--- a/src/components/ChainModeToggle.jsx
+++ b/src/components/ChainModeToggle.jsx
@@ -5,12 +5,11 @@ export default function ChainModeToggle({
   chainFilter, setChainFilter,
   chains = []
 }) {
-  const handleToggle = (e) => {
-    const on = e.target.checked;
-    setChainView(on);
-    if (!on) setChainFilter('');
-    else if (!chainFilter && chains.length) setChainFilter(chains[0].id);
-  };
+    const handleToggle = (e) => {
+      const on = e.target.checked;
+      setChainView(on);
+      if (on && !chainFilter && chains.length) setChainFilter(chains[0].id);
+    };
 
   return (
     <div className="mt-4">


### PR DESCRIPTION
## Summary
- keep chain filter when toggling Chain mode off
- save chain filter in session storage for the current session

## Testing
- `npm test` *(fails: Cannot use `import.meta` outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684b6b4a39c0832c91d2fb56901080a1