### PR TITLE
Unify modal style across app

### DIFF
--- a/src/components/PromptFormModal.jsx
+++ b/src/components/PromptFormModal.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { tokensOf } from '../utils/tokenCounter';
-import { supabase } from '../supabaseClient';        
+import { supabase } from '../supabaseClient';
+import { useDialog } from '../context/DialogContext';
 
 function hashColor(str = '') {
   let h = 0;
@@ -21,6 +22,8 @@ export default function PromptFormModal({
 }) {
   const defCat =
     categories.find((c) => c.name === 'Others')?.id || '';
+
+  const { showDialog } = useDialog();
 
   const [chains, setChains] = useState([]);
   useEffect(() => {
@@ -91,14 +94,22 @@ export default function PromptFormModal({
 
       if (!chain_order) {
         if (count >= 10) {
-          alert('There can be 10 prompts in this chain.');
+          showDialog({
+            title: 'Warning',
+            message: 'There can be 10 prompts in this chain.',
+            confirmText: 'OK'
+          });
           return;
         }
         chain_order = count + 1;
       } else {
 
         if (chain_order < 1 || chain_order > 10) {
-          alert('The number can range from 1 to 10.');
+          showDialog({
+            title: 'Warning',
+            message: 'The number can range from 1 to 10.',
+            confirmText: 'OK'
+          });
           return;
         }
         const { data: dup } = await supabase
@@ -108,9 +119,11 @@ export default function PromptFormModal({
           .eq('chain_order', chain_order)
           .neq('id', form.id);
         if (dup.length > 0) {
-          alert(
-            'This number is already taken in this chain!'
-          );
+          showDialog({
+            title: 'Warning',
+            message: 'This number is already taken in this chain!',
+            confirmText: 'OK'
+          });
           return;
         }
       }

--- a/src/components/PromptSidebar.jsx
+++ b/src/components/PromptSidebar.jsx
@@ -2,6 +2,8 @@ import { useEffect } from 'react';
 import { useSupabaseClient, useSession } from '@supabase/auth-helpers-react';
 import usePromptDump from '../hooks/usePromptDump';
 
+import { useDialog } from '../context/DialogContext';
+
 import ChainModeToggle from './ChainModeToggle';
 import SearchFilters   from './SearchFilters';
 import FavoritesToggle from './FavoritesToggle';
@@ -19,6 +21,7 @@ export default function PromptSidebar({
   const supabase = useSupabaseClient();
   const session  = useSession();
   const username = user?.email?.split('@')[0] || 'Guest';
+  const { showDialog } = useDialog();
 
   /* default chain */
   useEffect(() => {
@@ -29,7 +32,11 @@ export default function PromptSidebar({
 
   const handleLogout = async () => {
     await supabase.auth.signOut();
-    alert('Successfully logged out.');
+    showDialog({
+      title: 'Logout',
+      message: 'Successfully logged out.',
+      confirmText: 'OK'
+    });
   };
 
   const toggleFavoriteOnly = () => {


### PR DESCRIPTION
## Summary
- use `CustomDialog` style for all alerts
- show warnings via the dialog component
- display logout confirmation with `CustomDialog`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b706c8bcc832c9ab10b33137a64e0