### PR TITLE
Centralize i18n messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ npm run test          # runs Jest & React Testing Library
 npm run coverage      # generates coverage report
 ```
 
+### i18n
+All user-facing copy lives in `src/i18n/messages.en.json`. To add or edit text:
+1. Update the appropriate key in that file.
+2. Copy the file to `messages.<locale>.json` and translate the values to add a new language.
+3. Reference strings in code via the `t(key)` helper.
+4. Run `npm run lint:strings` to ensure no hard-coded text was introduced.
+
 ## 🧪 Production build
 ```bash
 pnpm build && pnpm preview

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "vite --open",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "jest"
+    "test": "jest",
+    "lint:strings": "node scripts/check-messages.js"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/scripts/check-messages.js
+++ b/scripts/check-messages.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..', 'src');
+const exts = ['.jsx', '.tsx'];
+let bad = false;
+
+function scan(file) {
+  const content = fs.readFileSync(file, 'utf8');
+  const lines = content.split(/\n/);
+  lines.forEach((line, idx) => {
+    if (line.includes('className') || line.includes('aria-')) return;
+    const regex = />\s*[^<{]*[A-Za-z][^<{]*</;
+    if (regex.test(line) && !line.includes('t(')) {
+      console.error(`Literal text in ${file}:${idx + 1}`);
+      bad = true;
+    }
+  });
+}
+
+function walk(dir) {
+  for (const f of fs.readdirSync(dir)) {
+    const p = path.join(dir, f);
+    if (fs.statSync(p).isDirectory()) {
+      if (f === '__tests__' || f === 'i18n') continue;
+      walk(p);
+    } else if (exts.includes(path.extname(p))) {
+      scan(p);
+    }
+  }
+}
+
+walk(root);
+if (bad) {
+  console.error('Run i18n helper for user-visible strings');
+  process.exit(1);
+}

--- a/src/PromptApp.jsx
+++ b/src/PromptApp.jsx
@@ -10,6 +10,7 @@ import { useDialog } from './context/DialogContext';
 import usePromptData from './hooks/usePromptData';
 import { filterPrompts } from './utils/promptFilter';
 import { toggleFavorit } from './utils/promptService';
+import { t } from './i18n';
 
 export default function PromptApp() {
   const session = useSession();
@@ -105,7 +106,7 @@ export default function PromptApp() {
       .update({ color })
       .eq('id', promptId);
     if (error) {
-      showDialog({ title: 'Error', message: error.message, confirmText: 'OK' });
+      showDialog({ title: t('Errors.Error'), message: error.message, confirmText: t('PromptCard.OK') });
     } else {
       fetchPrompts();
     }
@@ -114,18 +115,18 @@ export default function PromptApp() {
   const handleToggleFavorit = async (prompt) => {
     if (!prompt.id || !session.user.id) {
       showDialog({
-        title: 'Cannot set favorite',
-        message: 'Prompt ID or User ID is missing.',
-        confirmText: 'OK'
+        title: t('PromptCard.FavErrorTitle'),
+        message: t('PromptCard.FavIdMissing'),
+        confirmText: t('PromptCard.OK')
       });
       return;
     }
     const { error } = await toggleFavorit(supabase, prompt, session.user.id);
     if (error) {
       showDialog({
-        title: 'Cannot set favorite',
-        message: error.message || 'Error setting favorite.',
-        confirmText: 'OK'
+        title: t('PromptCard.FavErrorTitle'),
+        message: error.message || t('Errors.Error'),
+        confirmText: t('PromptCard.OK')
       });
     } else {
       fetchPrompts();

--- a/src/__tests__/PromptCard.test.jsx
+++ b/src/__tests__/PromptCard.test.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PromptCard from '../components/PromptCard';
+import { t } from '../i18n';
 
 jest.mock('../context/DialogContext', () => ({
   useDialog: () => ({ showDialog: jest.fn() })
@@ -43,7 +44,7 @@ describe('PromptCard Component', () => {
     renderCard();
     expect(screen.getByText('Test Prompt')).toBeInTheDocument();
     expect(screen.getByText('A test description')).toBeInTheDocument();
-    expect(screen.getByText('Public')).toBeInTheDocument();
+    expect(screen.getByText(t('PromptCard.Public'))).toBeInTheDocument();
     expect(screen.getByText('General')).toBeInTheDocument();
   });
 

--- a/src/__tests__/PromptFormModal.test.jsx
+++ b/src/__tests__/PromptFormModal.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PromptFormModal from '../components/PromptFormModal';
+import { t } from '../i18n';
 
 // React-DOM portal mock
 jest.mock('react-dom', () => ({
@@ -25,10 +26,10 @@ describe('PromptFormModal', () => {
   it('updates inputs and calls onSave & onClose', async () => {
     render(<PromptFormModal {...baseProps} />);
 
-    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'My title' } });
-    fireEvent.change(screen.getByPlaceholderText('Prompt text'), { target: { value: 'Hello' } });
+    fireEvent.change(screen.getByPlaceholderText(t('PromptForm.TitlePlaceholder')), { target: { value: 'My title' } });
+    fireEvent.change(screen.getByPlaceholderText(t('PromptForm.ContentPlaceholder')), { target: { value: 'Hello' } });
 
-    fireEvent.click(screen.getByText('Save'));
+    fireEvent.click(screen.getByText(t('PromptForm.Save')));
 
     await waitFor(() => {
       expect(baseProps.onSave).toHaveBeenCalledWith(

--- a/src/__tests__/PromptSidebar.test.jsx
+++ b/src/__tests__/PromptSidebar.test.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PromptSidebar from '../components/PromptSidebar';
+import { t } from '../i18n';
 
 jest.mock('@supabase/auth-helpers-react', () => ({
   useSupabaseClient: () => ({}),
@@ -42,21 +43,21 @@ describe('PromptSidebar', () => {
 
   it('renders username correctly', () => {
     render(<PromptSidebar {...baseProps()} />);
-    expect(screen.getByText('Logged in as')).toBeInTheDocument();
+    expect(screen.getByText(t('PromptSidebar.LoggedInAs'))).toBeInTheDocument();
     expect(screen.getByText('testuser')).toBeInTheDocument();
   });
 
   it('fires onNew on button click', () => {
     const props = baseProps();
     render(<PromptSidebar {...props} />);
-    fireEvent.click(screen.getByText('New prompt'));
+    fireEvent.click(screen.getByText(t('PromptSidebar.NewPrompt')));
     expect(props.onNew).toHaveBeenCalled();
   });
 
   it('updates search input', () => {
     const props = baseProps();
     render(<PromptSidebar {...props} />);
-    fireEvent.change(screen.getByPlaceholderText('Search'), {
+    fireEvent.change(screen.getByPlaceholderText(t('SearchFilters.SearchPlaceholder')), {
       target: { value: 'abc' },
     });
     expect(props.setSearch).toHaveBeenCalledWith('abc');
@@ -74,19 +75,19 @@ describe('PromptSidebar', () => {
   it('activates favorites toggle', () => {
     const props = baseProps();
     render(<PromptSidebar {...props} />);
-    fireEvent.click(screen.getByText('☆ Show Favorites'));
+    fireEvent.click(screen.getByText(t('FavoritesToggle.Show')));
     expect(props.setFavoriteOnly).toHaveBeenCalledWith(true);
     expect(props.deactivateChainView).toHaveBeenCalled();
   });
 
   it('exit-chain button disabled when inactive', () => {
     render(<PromptSidebar {...baseProps()} />);
-    expect(screen.getByText('🔗 Exit Chain View')).toBeDisabled();
+    expect(screen.getByText(t('PromptSidebar.ExitChain'))).toBeDisabled();
   });
 
   it('calls dump when "Dump Prompts" clicked', () => {
     render(<PromptSidebar {...baseProps()} />);
-    fireEvent.click(screen.getByText('📥 Dump Prompts'));
+    fireEvent.click(screen.getByText(t('PromptSidebar.DumpPrompts')));
     // a mockDump-ot a factory-n belül hoztuk létre → 1 hívás
     expect(require('../hooks/usePromptDump').default().dump).toHaveBeenCalled();
   });

--- a/src/components/ChainModeToggle.jsx
+++ b/src/components/ChainModeToggle.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { t } from '../i18n';
 
 export default function ChainModeToggle({
   chainView, setChainView,
@@ -19,7 +20,7 @@ export default function ChainModeToggle({
           checked={chainView}
           onChange={handleToggle}
           className="h-4 w-4 text-indigo-500 bg-gray-700 border-gray-600 rounded accent-indigo-500"/>
-        Chain mode
+        {t('ChainMode.Label')}
       </label>
 
       {chainView && (
@@ -28,7 +29,7 @@ export default function ChainModeToggle({
           value={chainFilter || ''}
           onChange={(e) => setChainFilter(e.target.value)}
         >
-          <option value="">— válassz chain-t —</option>
+          <option value="">{t('ChainMode.None')}</option>
           {chains.map((c) => (
             <option key={c.id} value={c.id}>
               {c.name}

--- a/src/components/FavoritesToggle.jsx
+++ b/src/components/FavoritesToggle.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { t } from '../i18n';
 
 export default function FavoritesToggle({ favoriteOnly, toggleFavoriteOnly }) {
   return (
@@ -10,7 +11,7 @@ export default function FavoritesToggle({ favoriteOnly, toggleFavoriteOnly }) {
           : 'bg-gray-700 text-gray-200'
       }`}
     >
-      {favoriteOnly ? '⭐ Showing Favorites' : '☆ Show Favorites'}
+      {favoriteOnly ? t('FavoritesToggle.Showing') : t('FavoritesToggle.Show')}
     </button>
   );
 }

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,5 +1,6 @@
 import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import { useState } from 'react';
+import { t } from '../i18n';
 
 export default function LoginForm() {
   const supabase = useSupabaseClient();
@@ -26,15 +27,15 @@ export default function LoginForm() {
         onSubmit={handleSubmit}
       >
         <h2 className="text-4xl font-extrabold tracking-wide text-transparent bg-clip-text bg-gradient-to-r from-purple-500 via-indigo-500 to-blue-500 text-center">
-          PrompTee ☕
+          {t('LoginForm.Title')}
         </h2>
         <h3 className="text-center text-xl font-semibold">
-          {isRegistering ? 'Register' : 'Login'}
+          {isRegistering ? t('LoginForm.Register') : t('LoginForm.Login')}
         </h3>
         {error && <p className="text-red-400 text-center">{error}</p>}
         <input
           type="email"
-          placeholder="Email"
+          placeholder={t('LoginForm.EmailPlaceholder')}
           className="field-dark mb-3 w-full"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
@@ -42,21 +43,21 @@ export default function LoginForm() {
         />
         <input
           type="password"
-          placeholder="Password"
+          placeholder={t('LoginForm.PasswordPlaceholder')}
           className="field-dark mb-3 w-full"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
         />
         <button type="submit" className="btn-blue w-full">
-          {isRegistering ? 'Create account' : 'Login'}
+          {isRegistering ? t('LoginForm.CreateAccount') : t('LoginForm.Login')}
         </button>
         <button
           type="button"
           onClick={() => setIsRegistering(!isRegistering)}
           className="w-full text-sm text-indigo-400 hover:underline focus:outline-none"
         >
-          {isRegistering ? 'Have an account? Log in' : 'No account? Register'}
+          {isRegistering ? t('LoginForm.ToggleToLogin') : t('LoginForm.ToggleToRegister')}
         </button>
       </form>
     </div>

--- a/src/components/PromptCard.jsx
+++ b/src/components/PromptCard.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { tokensOf } from '../utils/tokenCounter';
 import { useDialog } from '../context/DialogContext';
+import { t } from '../i18n';
 import './PromptCard.css';
 
 const bgMap = {
@@ -50,10 +51,10 @@ export default function PromptCard({
   const handleDelete = (e) => {
     e.stopPropagation();
     showDialog({
-      title: 'Delete Prompt',
-      message: 'Are you sure you want to delete this prompt?',
-      confirmText: 'Yes, Delete',
-      cancelText: 'No, Cancel',
+      title: t('PromptCard.DeleteTitle'),
+      message: t('PromptCard.DeleteMessage'),
+      confirmText: t('PromptCard.DeleteConfirm'),
+      cancelText: t('PromptCard.DeleteCancel'),
       onConfirm: () => onDelete(prompt.id),
     });
   };
@@ -62,9 +63,9 @@ export default function PromptCard({
     e.stopPropagation();
     if (!prompt.id) {
       showDialog({
-        title: 'Cannot set favorite',
-        message: 'Prompt ID is missing.',
-        confirmText: 'OK'
+        title: t('PromptCard.FavErrorTitle'),
+        message: t('PromptCard.FavIdMissing'),
+        confirmText: t('PromptCard.OK')
       });
       return;
     }
@@ -103,9 +104,9 @@ export default function PromptCard({
       <div className="prompt-tags mt-auto">
         <span className="tag category-tag">{prompt.category}</span>
         <span className={`tag visibility-tag ${prompt.is_public ? 'public' : 'private'}`}>
-          {prompt.is_public ? 'Public' : 'Private'}
+          {prompt.is_public ? t('PromptCard.Public') : t('PromptCard.Private')}
         </span>
-        <span className="tag token-tag">{tokenCount} tokens</span>
+        <span className="tag token-tag">{tokenCount} {t('PromptCard.TokensSuffix')}</span>
       </div>
 
       <div className="prompt-actions">
@@ -126,25 +127,27 @@ export default function PromptCard({
         </div>
 
         <button onClick={handleCopy} className="action-button copy relative">
-          📋 Copy
-          {copied && <span className="copied-tooltip">✅ Copied!</span>}
+          {t('PromptCard.Copy')}
+          {copied && (
+            <span className="copied-tooltip">{t('PromptCard.Copied')}</span>
+          )}
         </button>
 
         <button onClick={(e) => { e.stopPropagation(); onClone(prompt); }}
                 className="action-button clone">
-          🧬 Clone
+          {t('PromptCard.Clone')}
         </button>
 
         <button
           onClick={(e) => { e.stopPropagation(); isOwner ? onEdit() : onView(prompt); }}
           className="action-button edit"
         >
-          {isOwner ? '✏️ Edit' : '👁️ View'}
+          {isOwner ? t('PromptCard.Edit') : t('PromptCard.View')}
         </button>
 
         {isOwner && (
           <button onClick={handleDelete} className="action-button delete">
-            🗑️ Delete
+            {t('PromptCard.Delete')}
           </button>
         )}
       </div>

--- a/src/components/PromptFormModal.jsx
+++ b/src/components/PromptFormModal.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { tokensOf } from '../utils/tokenCounter';
 import { supabase } from '../supabaseClient';
 import { useDialog } from '../context/DialogContext';
+import { t } from '../i18n';
 
 function hashColor(str = '') {
   let h = 0;
@@ -95,9 +96,9 @@ export default function PromptFormModal({
       if (!chain_order) {
         if (count >= 10) {
           showDialog({
-            title: 'Warning',
-            message: 'There can be 10 prompts in this chain.',
-            confirmText: 'OK'
+            title: t('PromptForm.Warning'),
+            message: t('PromptForm.ChainLimit'),
+            confirmText: t('PromptForm.OK')
           });
           return;
         }
@@ -106,9 +107,9 @@ export default function PromptFormModal({
 
         if (chain_order < 1 || chain_order > 10) {
           showDialog({
-            title: 'Warning',
-            message: 'The number can range from 1 to 10.',
-            confirmText: 'OK'
+            title: t('PromptForm.Warning'),
+            message: t('PromptForm.ChainRange'),
+            confirmText: t('PromptForm.OK')
           });
           return;
         }
@@ -120,9 +121,9 @@ export default function PromptFormModal({
           .neq('id', form.id);
         if (dup.length > 0) {
           showDialog({
-            title: 'Warning',
-            message: 'This number is already taken in this chain!',
-            confirmText: 'OK'
+            title: t('PromptForm.Warning'),
+            message: t('PromptForm.ChainDup'),
+            confirmText: t('PromptForm.OK')
           });
           return;
         }
@@ -161,15 +162,15 @@ export default function PromptFormModal({
 
           <h2 className="text-2xl font-semibold mb-4">
             {readOnly
-              ? 'View Prompt'
+              ? t('PromptForm.View')
               : prompt.id
-              ? 'Edit Prompt'
-              : 'New Prompt'}
+              ? t('PromptForm.Edit')
+              : t('PromptForm.New')}
           </h2>
 
           <input
             required
-            placeholder="Title"
+            placeholder={t('PromptForm.TitlePlaceholder')}
             value={form.title}
             onChange={chg('title')}
             disabled={readOnly}
@@ -195,6 +196,7 @@ export default function PromptFormModal({
               disabled={readOnly}
               value={form.content}
               onChange={chg('content')}
+              placeholder={t('PromptForm.ContentPlaceholder')}
               className="flex-1 field-dark rounded-none resize-none
                          py-2 pl-0 text-base font-mono leading-7
                          min-h-[18rem]
@@ -208,13 +210,13 @@ export default function PromptFormModal({
             className="self-end -mt-2 mb-4 bg-indigo-600/90
                        px-3 py-1 rounded-full text-xs font-semibold"
           >
-            {tokenCount} tokens
+            {tokenCount} {t('PromptForm.TokensSuffix')}
           </span>
 
           {/* description + category */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
             <input
-              placeholder="Short description"
+              placeholder={t('PromptForm.DescriptionPlaceholder')}
               value={form.description}
               onChange={chg('description')}
               disabled={readOnly}
@@ -240,13 +242,13 @@ export default function PromptFormModal({
           {!readOnly && (
             <>
               <label className="flex flex-col gap-1 text-sm mb-4">
-                <span className="text-gray-400">🔗 Chain Type  (optional) </span>
+                <span className="text-gray-400">{t('PromptForm.ChainType')}</span>
                 <select
                   value={form.chain_id || ''}
                   onChange={chg('chain_id')}
                   className="field-dark rounded-none"
                 >
-                  <option value="">— none —</option>
+                  <option value="">{t('PromptForm.ChainNone')}</option>
                   {chains.map((c) => (
                     <option key={c.id} value={c.id}>
                       {c.name}
@@ -258,7 +260,7 @@ export default function PromptFormModal({
               {form.chain_id && (
                 <label className="flex flex-col gap-1 text-sm mb-4">
                   <span className="text-gray-400">
-                    📑 Chain order (1–10)
+                    {t('PromptForm.ChainOrderLabel')}
                   </span>
                   <input
                     type="number"
@@ -282,7 +284,7 @@ export default function PromptFormModal({
               onChange={chg('is_public')}
               disabled={readOnly}
             />
-            Public
+            {t('PromptForm.Public')}
           </label>
 
           <div className="mt-auto flex justify-end gap-3">
@@ -291,7 +293,7 @@ export default function PromptFormModal({
               onClick={onClose}
               className="text-gray-400 hover:text-gray-200"
             >
-              {readOnly ? 'Close' : 'Cancel'}
+              {readOnly ? t('PromptForm.Close') : t('PromptForm.Cancel')}
             </button>
             {!readOnly && (
               <button
@@ -299,7 +301,7 @@ export default function PromptFormModal({
                 className="bg-green-600 hover:bg-green-500 px-6 py-2
                            rounded-md font-semibold shadow"
               >
-                Save
+                {t('PromptForm.Save')}
               </button>
             )}
           </div>

--- a/src/components/PromptSidebar.jsx
+++ b/src/components/PromptSidebar.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useSupabaseClient, useSession } from '@supabase/auth-helpers-react';
 import usePromptDump from '../hooks/usePromptDump';
+import { t } from '../i18n';
 
 import { useDialog } from '../context/DialogContext';
 
@@ -33,9 +34,9 @@ export default function PromptSidebar({
   const handleLogout = async () => {
     await supabase.auth.signOut();
     showDialog({
-      title: 'Logout',
-      message: 'Successfully logged out.',
-      confirmText: 'OK'
+      title: t('PromptSidebar.LogoutTitle'),
+      message: t('PromptSidebar.LogoutMsg'),
+      confirmText: t('PromptSidebar.OK')
     });
   };
 
@@ -67,11 +68,11 @@ export default function PromptSidebar({
     <aside className="sidebar-box flex flex-col justify-between">
       <div>
         <h2 className="text-4xl font-extrabold tracking-wide text-transparent bg-clip-text bg-gradient-to-r from-purple-500 via-indigo-500 to-blue-500 text-center">
-          PrompTee 🍵
+          {t('PromptSidebar.Title')}
         </h2>
 
         <button onClick={onNew} className="btn-blue mt-4 w-full shadow-lg">
-          New prompt
+          {t('PromptSidebar.NewPrompt')}
         </button>
 
         <ChainModeToggle
@@ -110,13 +111,13 @@ export default function PromptSidebar({
               : 'bg-gray-700 text-gray-400 cursor-not-allowed'
           }`}
         >
-          🔗 Exit Chain View
+          {t('PromptSidebar.ExitChain')}
         </button>
 
         {/* user info */}
         <div className="border-t border-gray-700 my-4" />
         <div className="text-center text-sm text-gray-400">
-          Logged in as{' '}
+          {t('PromptSidebar.LoggedInAs')}{' '}
           <span className="font-semibold text-indigo-400">{username}</span>
         </div>
       </div>
@@ -126,7 +127,7 @@ export default function PromptSidebar({
           onClick={handleLogout}
           className="mt-2 text-sm font-semibold bg-red-700 hover:bg-red-600 transition-colors text-white rounded-lg py-1 px-3"
         >
-          Logout
+          {t('PromptSidebar.Logout')}
         </button>
 
         <button
@@ -134,7 +135,7 @@ export default function PromptSidebar({
           disabled={dumpLoading}
           className="mt-2 ml-2 text-sm bg-gray-700 hover:bg-gray-600 transition-colors text-white rounded-lg py-1 px-3"
         >
-          {dumpLoading ? '⏳ Dumping…' : '📥 Dump Prompts'}
+          {dumpLoading ? t('PromptSidebar.Dumping') : t('PromptSidebar.DumpPrompts')}
         </button>
 
         {dumpError && (

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { t } from '../i18n';
 
 export default function SearchFilters({
   search, setSearch,
@@ -13,7 +14,7 @@ export default function SearchFilters({
       <div className="relative mt-4">
         <input
           type="text"
-          placeholder="Search"
+          placeholder={t('SearchFilters.SearchPlaceholder')}
           value={search}
           onChange={(e) => setSearch(e.target.value.toLowerCase())}
           className="field-dark w-full pr-20"
@@ -41,7 +42,7 @@ export default function SearchFilters({
         onClick={clearFilters}
         className="mt-2 w-full py-2 rounded-lg bg-gray-600 hover:bg-gray-500 transition-colors font-semibold"
       >
-        🗑️ Clear filters
+        {t('SearchFilters.Clear')}
       </button>
     </>
   );

--- a/src/hooks/useIdleTimeout.tsx
+++ b/src/hooks/useIdleTimeout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useRef } from 'react';
 import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import { useDialog } from '../context/DialogContext';
+import { t } from '../i18n';
 
 export default function useIdleTimeout(timeoutMinutes = 30) {
   const supabase = useSupabaseClient();
@@ -18,9 +19,9 @@ export default function useIdleTimeout(timeoutMinutes = 30) {
     clear();
     await supabase.auth.signOut();
     showDialog({
-      title: 'Session Expired',
-      message: 'You were logged out due to inactivity.',
-      confirmText: 'OK',
+      title: t('IdleTimeout.ExpiredTitle'),
+      message: t('IdleTimeout.ExpiredMsg'),
+      confirmText: t('IdleTimeout.OK'),
       onConfirm: hideDialog,
     });
   }, [supabase, showDialog, hideDialog]);

--- a/src/hooks/usePromptData.js
+++ b/src/hooks/usePromptData.js
@@ -1,6 +1,7 @@
 // hooks/usePromptData.js
 import { useState, useEffect, useCallback } from 'react';
 import { fetchCategories, fetchPrompts, savePrompt, deletePrompt, clonePrompt, toggleFavorit } from '../utils/promptService';
+import { t } from '../i18n';
 
 export default function usePromptData(supabase, session, showDialog) {
   const [prompts, setPrompts] = useState([]);
@@ -8,13 +9,13 @@ export default function usePromptData(supabase, session, showDialog) {
 
   const loadCategories = async () => {
     const { data, error } = await fetchCategories(supabase);
-    if (error) showDialog({ title: 'Error', message: error.message, confirmText: 'OK' });
+    if (error) showDialog({ title: t('Errors.Error'), message: error.message, confirmText: t('PromptCard.OK') });
     else setCategories(data);
   };
 
   const loadPrompts = useCallback(async () => {
     const { data, error } = await fetchPrompts(supabase);
-    if (error) showDialog({ title: 'Error', message: error.message, confirmText: 'OK' });
+    if (error) showDialog({ title: t('Errors.Error'), message: error.message, confirmText: t('PromptCard.OK') });
     else setPrompts(data);
   }, [supabase, showDialog]);
 
@@ -40,7 +41,7 @@ export default function usePromptData(supabase, session, showDialog) {
 
       const error = await savePrompt(supabase, promptToSave, session.user.id);
       if (error) {
-        showDialog({ title: 'Error', message: error.message, confirmText: 'OK' });
+        showDialog({ title: t('Errors.Error'), message: error.message, confirmText: t('PromptCard.OK') });
       } else {
         loadPrompts();
       }
@@ -48,19 +49,19 @@ export default function usePromptData(supabase, session, showDialog) {
 
     handleDelete: async (id) => {
       const error = await deletePrompt(supabase, id);
-      if (error) showDialog({ title: 'Error', message: error.message, confirmText: 'OK' });
+      if (error) showDialog({ title: t('Errors.Error'), message: error.message, confirmText: t('PromptCard.OK') });
       else loadPrompts();
     },
 
     handleClone: async (prompt) => {
       const error = await clonePrompt(supabase, prompt, session.user.id);
-      if (error) showDialog({ title: 'Error', message: error.message, confirmText: 'OK' });
+      if (error) showDialog({ title: t('Errors.Error'), message: error.message, confirmText: t('PromptCard.OK') });
       else loadPrompts();
     },
 
     handleToggleFavorit: async (prompt) => {
       const error = await toggleFavorit(supabase, prompt, session.user.id);
-      if (error) showDialog({ title: 'Error', message: error.message, confirmText: 'OK' });
+      if (error) showDialog({ title: t('Errors.Error'), message: error.message, confirmText: t('PromptCard.OK') });
       else loadPrompts();
     },
   };

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,25 @@
+import en from './messages.en.json';
+
+let messages = en;
+let currentLocale = 'en';
+
+export function setLocale(locale) {
+  try {
+    messages = require(`./messages.${locale}.json`);
+    currentLocale = locale;
+  } catch (e) {
+    console.warn(`Missing locale ${locale}`);
+  }
+}
+
+export function t(key, vars = {}) {
+  const parts = key.split('.');
+  let str = parts.reduce((obj, p) => (obj ? obj[p] : undefined), messages);
+  if (typeof str !== 'string') return key;
+  Object.entries(vars).forEach(([k, v]) => {
+    str = str.replace(new RegExp(`{${k}}`, 'g'), v);
+  });
+  return str;
+}
+
+export { currentLocale };

--- a/src/i18n/messages.en.json
+++ b/src/i18n/messages.en.json
@@ -1,0 +1,83 @@
+{
+  "LoginForm": {
+    "Title": "PrompTee \u2615",
+    "Register": "Register",
+    "Login": "Login",
+    "CreateAccount": "Create account",
+    "ToggleToLogin": "Have an account? Log in",
+    "ToggleToRegister": "No account? Register",
+    "EmailPlaceholder": "Email",
+    "PasswordPlaceholder": "Password"
+  },
+  "PromptCard": {
+    "DeleteTitle": "Delete Prompt",
+    "DeleteMessage": "Are you sure you want to delete this prompt?",
+    "DeleteConfirm": "Yes, Delete",
+    "DeleteCancel": "No, Cancel",
+    "FavErrorTitle": "Cannot set favorite",
+    "FavIdMissing": "Prompt ID is missing.",
+    "OK": "OK",
+    "Public": "Public",
+    "Private": "Private",
+    "TokensSuffix": "tokens",
+    "Copy": "\ud83d\uDCCB Copy",
+    "Copied": "\u2705 Copied!",
+    "Clone": "\ud83e\uddec Clone",
+    "Edit": "\u270f\ufe0f Edit",
+    "View": "\ud83d\udc41\ufe0f View",
+    "Delete": "\ud83d\udc9b Delete" 
+  },
+  "PromptForm": {
+    "View": "View Prompt",
+    "Edit": "Edit Prompt",
+    "New": "New Prompt",
+    "TitlePlaceholder": "Title",
+    "ContentPlaceholder": "Prompt text",
+    "DescriptionPlaceholder": "Short description",
+    "ChainType": "\ud83d\udd17 Chain Type  (optional)",
+    "ChainNone": "\u2014 none \u2014",
+    "ChainOrderLabel": "\ud83d\udcc1 Chain order (1\u201310)",
+    "Public": "Public",
+    "Close": "Close",
+    "Cancel": "Cancel",
+    "Save": "Save",
+    "Warning": "Warning",
+    "ChainLimit": "There can be 10 prompts in this chain.",
+    "ChainRange": "The number can range from 1 to 10.",
+    "ChainDup": "This number is already taken in this chain!",
+    "TokensSuffix": "tokens",
+    "OK": "OK"
+  },
+  "PromptSidebar": {
+    "Title": "PrompTee \ud83c\udf75",
+    "NewPrompt": "New prompt",
+    "ExitChain": "\ud83d\udd17 Exit Chain View",
+    "LoggedInAs": "Logged in as",
+    "Logout": "Logout",
+    "DumpPrompts": "\ud83d\udce5 Dump Prompts",
+    "Dumping": "\u23f3 Dumping\u2026",
+    "LogoutTitle": "Logout",
+    "LogoutMsg": "Successfully logged out.",
+    "OK": "OK"
+  },
+  "SearchFilters": {
+    "SearchPlaceholder": "Search",
+    "Clear": "\ud83d\udd1a Clear filters"
+  },
+  "FavoritesToggle": {
+    "Show": "\u2606 Show Favorites",
+    "Showing": "\u2b50 Showing Favorites"
+  },
+  "ChainMode": {
+    "Label": "Chain mode",
+    "None": "\u2014 choose chain \u2014"
+  },
+  "IdleTimeout": {
+    "ExpiredTitle": "Session Expired",
+    "ExpiredMsg": "You were logged out due to inactivity.",
+    "OK": "OK"
+  },
+  "Errors": {
+    "Error": "Error"
+  }
+}


### PR DESCRIPTION
## Summary
- centralize all UI text in new `src/i18n/messages.en.json`
- provide `t()` helper to fetch messages
- refactor components and tests to use message keys
- add lint script detecting literal UI strings
- document i18n workflow in README

## Testing
- `npm run lint:strings`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b737389f8832cb632b8a624220b2f