### PR TITLE
Fix React import in PromptApp

### DIFF
--- a/src/PromptApp.jsx
+++ b/src/PromptApp.jsx
@@ -1,5 +1,5 @@
 import { useSession, useSupabaseClient } from '@supabase/auth-helpers-react';
-import { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import PromptSidebar from './components/PromptSidebar';
 import PromptCard from './components/PromptCard';
 import PromptFormModal from './components/PromptFormModal';


### PR DESCRIPTION
## Summary
- include default `React` import in `PromptApp.jsx` to avoid runtime errors

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b7d7bc7a0832c92e3047dffff8655