### PR TITLE
Update chain view animation container

### DIFF
--- a/src/PromptApp.jsx
+++ b/src/PromptApp.jsx
@@ -164,7 +164,7 @@ export default function PromptApp() {
       />
 
       <main className="flex-1">
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 auto-rows-max items-start">
+        <div className="cards-container grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 auto-rows-max items-start">
           {filtered.map((prompt, idx) => (
             <React.Fragment key={prompt.id}>
               <PromptCard

--- a/src/components/PromptCard.css
+++ b/src/components/PromptCard.css
@@ -195,7 +195,33 @@
   opacity: 0;
 }
 
-.chain-view-mode:hover ~ .chain-separator::before {
+
+/* Show chain line when the card container is hovered */
+.cards-container:hover .chain-separator::before {
+  opacity: 1;
+  animation: chain-dash-vert 0.6s linear infinite;
+}
+
+/* Container level dashed line */
+.cards-container {
+  position: relative;
+}
+
+.cards-container::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  pointer-events: none;
+  background-image: repeating-linear-gradient(#fff, #fff 6px, transparent 6px, transparent 12px);
+  background-repeat: repeat-y;
+  opacity: 0;
+}
+
+.cards-container:hover::before {
   opacity: 1;
   animation: chain-dash-vert 0.6s linear infinite;
 }


### PR DESCRIPTION
## Summary
- add `cards-container` wrapper for prompt cards
- animate chain separator when container hovered
- create container-level dashed line that runs top to bottom

## Testing
- `npm test` *(fails: Cannot destructure property 'showDialog' of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_684b83624998832c800d44cf8dd4386b