### PR TITLE
Implement external hover icon

### DIFF
--- a/src/assets/hover-icon.svg
+++ b/src/assets/hover-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M8 4l8 8-8 8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/PromptCard.css
+++ b/src/components/PromptCard.css
@@ -172,6 +172,24 @@
   box-shadow: 0 1px 4px rgba(0,0,0,0.35);
 }
 
+/* arrow shown when hovering cards outside chain view */
+.hover-icon {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  opacity: 0;
+  transform: translateX(4px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+.prompt-card.has-chain-order:not(.chain-view-mode):hover .hover-icon {
+  opacity: 1;
+  transform: translateX(0);
+}
+
 /* --- chain hover line ------------------------------------------------------ */
 /* line connecting chained cards */
 .chain-separator {

--- a/src/components/PromptCard.jsx
+++ b/src/components/PromptCard.jsx
@@ -3,6 +3,7 @@ import { tokensOf } from '../utils/tokenCounter';
 import { useDialog } from '../context/DialogContext';
 import { t } from '../i18n';
 import './PromptCard.css';
+import hoverIcon from '../assets/hover-icon.svg';
 
 const bgMap = {
   default: '#313338',
@@ -70,7 +71,7 @@ export default function PromptCard({
 
   return (
     <div
-      className={`prompt-card relative ${chainViewActive ? 'chain-view-mode' : ''}`}
+      className={`prompt-card relative ${chainViewActive ? 'chain-view-mode' : ''} ${prompt.chain_order != null ? 'has-chain-order' : ''}`}
       /* relative ⇒ badge pozícionálás */
       style={{ background: bgMap[color] }}
       tabIndex={-1}
@@ -81,6 +82,9 @@ export default function PromptCard({
         <div className="chain-order-badge">
           {prompt.chain_order}
         </div>
+      )}
+      {!chainViewActive && prompt.chain_order != null && (
+        <img src={hoverIcon} alt="" className="hover-icon" />
       )}
 
       <header>


### PR DESCRIPTION
## Summary
- create `hover-icon.svg` under `src/assets`
- load the hover icon in `PromptCard` and only display it when the card is part of a chain but chain view is inactive
- scope the hover animation to only activate when chain view is inactive and the card has a chain order

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb0d8a3fc832c805418445f3aa28c