### PR TITLE
Extract hover icon asset and conditionally enable hover

### DIFF
--- a/src/assets/hover-icon.svg
+++ b/src/assets/hover-icon.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M13 2L3 14H12L11 22L21 10H13L13 2Z" stroke="#00FFFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/PromptCard.css
+++ b/src/components/PromptCard.css
@@ -78,7 +78,7 @@
   pointer-events: none;
 }
 
-.prompt-card:hover .hover-icon {
+.prompt-card.hover-enabled:hover .hover-icon {
   opacity: 1;
   transform: translateY(-3px);
 }

--- a/src/components/PromptCard.jsx
+++ b/src/components/PromptCard.jsx
@@ -3,6 +3,7 @@ import { tokensOf } from '../utils/tokenCounter';
 import { useDialog } from '../context/DialogContext';
 import { t } from '../i18n';
 import './PromptCard.css';
+import hoverIconUrl from '../assets/hover-icon.svg';
 
 const bgMap = {
   default: '#313338',
@@ -70,7 +71,7 @@ export default function PromptCard({
 
   return (
     <div
-      className={`prompt-card relative ${chainViewActive ? 'chain-view-mode' : ''}`}
+      className={`prompt-card relative ${chainViewActive ? 'chain-view-mode' : ''} ${(!chainViewActive && prompt.chain_order != null) ? 'hover-enabled' : ''}`}
       style={{ background: bgMap[color] }}
       tabIndex={-1}
       onFocus={(e) => e.currentTarget.blur()}
@@ -83,12 +84,8 @@ export default function PromptCard({
       )}
 
       <span className="hover-icon">
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
-           xmlns="http://www.w3.org/2000/svg">
-        <path d="M13 2L3 14H12L11 22L21 10H13L13 2Z" stroke="#00FFFF"
-              strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-      </svg>
-    </span>
+        <img src={hoverIconUrl} alt="" width={20} height={20} />
+      </span>
     
       <header>
         <h3 className="prompt-title">{prompt.title}</h3>


### PR DESCRIPTION
## Summary
- move hover indicator SVG into `src/assets`
- load hover icon image in `PromptCard` component
- activate hover animation only when chain view is inactive and a chain order exists

## Testing
- `npm install`
- `npm test` *(fails: Cannot destructure property 'showDialog' of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_684cb38653a0832c8e44d7b971af8d5f