### PR TITLE
Limit shine animation to single cycle

### DIFF
--- a/src/components/PromptCard.css
+++ b/src/components/PromptCard.css
@@ -52,6 +52,7 @@
   transition: transform 0.3s ease;
 }
 
+
 .prompt-card::before {
   content: '';
   position: absolute;
@@ -59,13 +60,14 @@
   width: 200%;
   height: 100%;
   background: linear-gradient(120deg, rgba(0, 255, 200, 0.2), rgba(0, 150, 255, 0.2), rgba(0, 255, 200, 0.2));
-  animation: shine 3s infinite;
+  animation: none;
   opacity: 0;
   transition: opacity 0.5s ease;
 }
 
 .prompt-card:hover::before {
   opacity: 1;
+  animation: shine 3.5s forwards;
 }
 
 .hover-icon {


### PR DESCRIPTION
## Summary
- remove infinite looping shine animation
- trigger shine animation only on hover and stop after 3.5 seconds

## Testing
- `npm install`
- `npm run test` *(fails: Cannot destructure property 'showDialog' ...)*

------
https://chatgpt.com/codex/tasks/task_e_684cb6ac04ac832ca166dee0d7a97d1c