### PR TITLE
Rearrange sidebar toggles

### DIFF
--- a/src/components/PromptSidebar.jsx
+++ b/src/components/PromptSidebar.jsx
@@ -76,13 +76,6 @@ export default function PromptSidebar({
           {t('PromptSidebar.NewPrompt')}
         </button>
 
-        <ChainModeToggle
-          chainView={chainView}
-          setChainView={setChainView}
-          chainFilter={chainFilter}
-          setChainFilter={setChainFilter}
-          chains={chains}
-        />
 
         {!favoriteOnly && !chainView && (
           <SearchFilters
@@ -103,6 +96,14 @@ export default function PromptSidebar({
         )}
 
         <ArchivedToggle />
+
+        <ChainModeToggle
+          chainView={chainView}
+          setChainView={setChainView}
+          chainFilter={chainFilter}
+          setChainFilter={setChainFilter}
+          chains={chains}
+        />
 
         {/* Exit Chain View */}
         <button


### PR DESCRIPTION
## Summary
- move archived and chain mode toggles below the favorites button

## Testing
- `npm run lint:strings`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d560659fc832c83a80005f4c3d129