### PR TITLE
Hide toggles while chain mode active

### DIFF
--- a/src/components/PromptSidebar.jsx
+++ b/src/components/PromptSidebar.jsx
@@ -76,13 +76,15 @@ export default function PromptSidebar({
           {t('PromptSidebar.NewPrompt')}
         </button>
 
-        <ChainModeToggle
-          chainView={chainView}
-          setChainView={setChainView}
-          chainFilter={chainFilter}
-          setChainFilter={setChainFilter}
-          chains={chains}
-        />
+        {!chainView && (
+          <ChainModeToggle
+            chainView={chainView}
+            setChainView={setChainView}
+            chainFilter={chainFilter}
+            setChainFilter={setChainFilter}
+            chains={chains}
+          />
+        )}
 
         {!favoriteOnly && !chainView && (
           <SearchFilters
@@ -102,7 +104,7 @@ export default function PromptSidebar({
           />
         )}
 
-        <ArchivedToggle />
+        {!chainView && <ArchivedToggle />}
 
         {/* Exit Chain View */}
         <button


### PR DESCRIPTION
## Summary
- hide the Chain Mode and Archived Mode checkboxes when chain mode is active

## Testing
- `npm test`
- `npm run lint:strings`


------
https://chatgpt.com/codex/tasks/task_e_684d5897fed0832cb518452ee9f02693