### PR TITLE
Reorder sidebar toggles

### DIFF
--- a/src/__tests__/PromptSidebar.test.jsx
+++ b/src/__tests__/PromptSidebar.test.jsx
@@ -121,7 +121,7 @@ describe('PromptSidebar', () => {
       </UIProvider>
     );
     fireEvent.click(screen.getByText(t('PromptSidebar.DumpPrompts')));
-    // a mockDump-ot a factory-n belül hoztuk létre → 1 hívás
+    // mockDump was created inside the factory → one call
     expect(require('../hooks/usePromptDump').default().dump).toHaveBeenCalled();
   });
 

--- a/src/__tests__/promptService.test.js
+++ b/src/__tests__/promptService.test.js
@@ -11,7 +11,7 @@ const mockSupabase = {
 
 describe('toggleFavorit', () => {
 
-  // UUID MOCK CSAK EBBEN A BLOKKBAN ÉRVÉNYES
+  // UUID mock is valid only within this block
   jest.mock('uuid', () => ({ v4: () => 'test-uuid' }), { virtual: true });
 
   beforeEach(() => {

--- a/src/__tests__/promptService2.test.js
+++ b/src/__tests__/promptService2.test.js
@@ -3,7 +3,7 @@ import { createInMemoryDb } from '../inMemoryDb';
 let db, client;
 let uuidv4, TEST_USER_ID;
 
-// Az egész describe blokk ki lesz hagyva, semmi se fut le belőle.
+// The entire describe block is skipped; nothing will run.
 describe.skip('Prompt Favorites Logic Integration Tests (Full table & logic)', () => {
   
   beforeEach(async () => {

--- a/src/components/PromptFormModal.jsx
+++ b/src/components/PromptFormModal.jsx
@@ -152,7 +152,7 @@ export default function PromptFormModal({
                    rounded-2xl shadow-[0_25px_80px_rgba(0,0,0,0.4)]
                    text-gray-200"
       >
-        {/* színes fejléc-csík */}
+        {/* colored header stripe */}
         <div
           style={{ backgroundColor: headColor }}
           className="h-2 w-full"

--- a/src/components/PromptSidebar.jsx
+++ b/src/components/PromptSidebar.jsx
@@ -75,16 +75,6 @@ export default function PromptSidebar({
           {t('PromptSidebar.NewPrompt')}
         </button>
 
-        {!chainView && (
-          <ChainModeToggle
-            chainView={chainView}
-            setChainView={setChainView}
-            chainFilter={chainFilter}
-            setChainFilter={setChainFilter}
-            chains={chains}
-          />
-        )}
-
         {!favoriteOnly && !chainView && (
           <SearchFilters
             search={search}
@@ -103,6 +93,16 @@ export default function PromptSidebar({
           />
         )}
 
+        {!chainView && (
+          <ChainModeToggle
+            chainView={chainView}
+            setChainView={setChainView}
+            chainFilter={chainFilter}
+            setChainFilter={setChainFilter}
+            chains={chains}
+          />
+        )}
+
         {!chainView && <ArchivedToggle />}
 
         <button
@@ -117,7 +117,7 @@ export default function PromptSidebar({
           {t('PromptSidebar.ExitChain')}
         </button>
 
-        {/* felhasználói információ */}
+        {/* user information */}
         <div className="border-t border-gray-700 my-4" />
         <div className="text-center text-sm text-gray-400">
           {t('PromptSidebar.LoggedInAs')}{' '}
@@ -125,7 +125,7 @@ export default function PromptSidebar({
         </div>
       </div>
 
-      {/* lábléc gombok */}
+      {/* footer buttons */}
       <div className="mt-auto pt-4 text-center text-sm text-gray-400 border-t border-gray-700">
         <button
           onClick={handleLogout}

--- a/src/hooks/useIdleTimeout.tsx
+++ b/src/hooks/useIdleTimeout.tsx
@@ -37,7 +37,7 @@ export default function useIdleTimeout(timeoutMinutes = 30) {
       'touchstart', 'touchmove', 'scroll', 'visibilitychange'
     ];
     events.forEach(e => window.addEventListener(e, resetTimeout));
-    resetTimeout();               // indítás mountkor
+    resetTimeout();               // start on mount
 
     return () => {
       events.forEach(e => window.removeEventListener(e, resetTimeout));


### PR DESCRIPTION
## Summary
- move `ChainModeToggle` and `ArchivedToggle` below the favorites button
- translate non‑English comments

## Testing
- `npm test`
- `npm run lint:strings`


------
https://chatgpt.com/codex/tasks/task_e_684d5cad42c8832c81b07fa847ab189b