### PR TITLE
Add clone tooltip

### DIFF
--- a/src/components/PromptCard.css
+++ b/src/components/PromptCard.css
@@ -172,7 +172,14 @@
 
 /* ---------- copy tooltip ---------- */
 .action-button.copy { position:relative; }
+.action-button.clone { position:relative; }
 .copied-tooltip {
+  position:absolute; top:-35px; left:50%; transform:translateX(-50%);
+  background:#10b981; color:#fff; padding:4px 10px; border-radius:6px;
+  font-size:0.8rem; white-space:nowrap; box-shadow:0 2px 6px rgba(0,0,0,0.25);
+  opacity:0; animation:fadeTooltip 1.5s forwards; pointer-events:none;
+}
+.cloned-tooltip {
   position:absolute; top:-35px; left:50%; transform:translateX(-50%);
   background:#10b981; color:#fff; padding:4px 10px; border-radius:6px;
   font-size:0.8rem; white-space:nowrap; box-shadow:0 2px 6px rgba(0,0,0,0.25);

--- a/src/components/PromptCard.jsx
+++ b/src/components/PromptCard.jsx
@@ -26,6 +26,7 @@ export default function PromptCard({
 
   const [color, setColor] = useState(prompt.color || 'default');
   const [copied, setCopied] = useState(false);
+  const [cloned, setCloned] = useState(false);
 
   useEffect(() => {
     setColor(prompt.color || 'default');
@@ -43,6 +44,13 @@ export default function PromptCard({
     onCopy();
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
+  };
+
+  const handleClone = (e) => {
+    e.stopPropagation();
+    onClone(prompt);
+    setCloned(true);
+    setTimeout(() => setCloned(false), 1500);
   };
 
   const handleDelete = (e) => {
@@ -151,9 +159,11 @@ return (
         )}
       </button>
 
-      <button onClick={(e) => { e.stopPropagation(); onClone(prompt); }}
-              className="action-button clone">
+      <button onClick={handleClone} className="action-button clone relative">
         {t('PromptCard.Clone')}
+        {cloned && (
+          <span className="cloned-tooltip">{t('PromptCard.Cloned')}</span>
+        )}
       </button>
 
       {!prompt.archived_at ? (

--- a/src/i18n/messages.en.json
+++ b/src/i18n/messages.en.json
@@ -23,6 +23,7 @@
     "Copy": "📋 Copy",
     "Copied": "✅ Copied!",
     "Clone": "🧬 Clone",
+    "Cloned": "✅ Cloned!",
     "Edit": "✏️",
     "View": "👁️ View",
     "Delete": "🗑️",


### PR DESCRIPTION
## Summary
- show "CLONED" tooltip after cloning prompt
- reuse same style/animation as copy tooltip
- add English translation for "Cloned"

## Testing
- `npm install`
- `npm test`
- `npm run lint:strings`


------
https://chatgpt.com/codex/tasks/task_e_684d63298944832c8508e6d49c8f25fa