### PR TITLE
Improve login feedback

### DIFF
--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -7,17 +7,26 @@ export default function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
   const [isRegistering, setIsRegistering] = useState(false);
 
   async function handleSubmit(e) {
     e.preventDefault();
-    let error;
+    let resultError;
     if (isRegistering) {
-      ({ error } = await supabase.auth.signUp({ email, password }));
+      const { error } = await supabase.auth.signUp({ email, password });
+      resultError = error;
+      if (!error) setSuccess(t('LoginForm.RegisterSuccess'));
     } else {
-      ({ error } = await supabase.auth.signInWithPassword({ email, password }));
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      resultError = error;
     }
-    if (error) setError(error.message);
+    if (resultError) {
+      setError(resultError.message);
+      setSuccess('');
+    } else {
+      setError('');
+    }
   }
 
   return (
@@ -33,6 +42,7 @@ export default function LoginForm() {
           {isRegistering ? t('LoginForm.Register') : t('LoginForm.Login')}
         </h3>
         {error && <p className="text-red-400 text-center">{error}</p>}
+        {success && <p className="text-green-400 text-center">{success}</p>}
         <input
           type="email"
           placeholder={t('LoginForm.EmailPlaceholder')}
@@ -54,7 +64,11 @@ export default function LoginForm() {
         </button>
         <button
           type="button"
-          onClick={() => setIsRegistering(!isRegistering)}
+          onClick={() => {
+            setIsRegistering(!isRegistering);
+            setError('');
+            setSuccess('');
+          }}
           className="w-full text-sm text-indigo-400 hover:underline focus:outline-none"
         >
           {isRegistering ? t('LoginForm.ToggleToLogin') : t('LoginForm.ToggleToRegister')}

--- a/src/i18n/messages.en.json
+++ b/src/i18n/messages.en.json
@@ -7,7 +7,8 @@
     "ToggleToLogin": "Have an account? Log in",
     "ToggleToRegister": "No account? Register",
     "EmailPlaceholder": "Email",
-    "PasswordPlaceholder": "Password"
+    "PasswordPlaceholder": "Password",
+    "RegisterSuccess": "Registration successful! Check your email to confirm."
   },
   "PromptCard": {
     "DeleteTitle": "Delete Prompt",


### PR DESCRIPTION
## Summary
- show registration success message
- clear errors on successful login or register
- reset messages when toggling mode

## Testing
- `npm run lint:strings`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d89c7162c832c91f4da4922c557f9