### PR TITLE
Improve registration UX and card responsiveness

### DIFF
--- a/src/PromptApp.jsx
+++ b/src/PromptApp.jsx
@@ -166,7 +166,10 @@ export default function PromptApp() {
       />
 
       <main className="flex-1">
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 auto-rows-max items-start">
+        <div
+          className="grid gap-6 auto-rows-max items-start"
+          style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' }}
+        >
           {filtered.map((prompt, idx) => (
             <React.Fragment key={prompt.id}>
               <PromptCard

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -16,7 +16,11 @@ export default function LoginForm() {
     if (isRegistering) {
       const { error } = await supabase.auth.signUp({ email, password });
       resultError = error;
-      if (!error) setSuccess(t('LoginForm.RegisterSuccess'));
+      if (!error) {
+        setSuccess(t('LoginForm.RegisterSuccess'));
+        setEmail('');
+        setPassword('');
+      }
     } else {
       const { error } = await supabase.auth.signInWithPassword({ email, password });
       resultError = error;

--- a/src/components/PromptCard.css
+++ b/src/components/PromptCard.css
@@ -1,6 +1,6 @@
 
 .prompt-card {
-  @apply rounded-xl flex flex-col relative;
+  @apply rounded-xl flex flex-col relative min-h-60 min-w-[280px];
   padding: 20px;
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(8px);


### PR DESCRIPTION
## Summary
- clear login input fields once registration succeeds
- set minimum size for prompt cards
- make prompt grid adapt to screen width

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint:strings`

------
https://chatgpt.com/codex/tasks/task_e_684d8bce1cd4832caab37b8f7bcbf8bf