### PR TITLE
Refactor PromptCard style

### DIFF
--- a/src/PromptApp.jsx
+++ b/src/PromptApp.jsx
@@ -166,7 +166,10 @@ export default function PromptApp() {
       />
 
       <main className="flex-1">
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 auto-rows-max items-start">
+        <div
+          className="grid gap-6 auto-rows-max items-start"
+          style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))' }}
+        >
           {filtered.map((prompt, idx) => (
             <React.Fragment key={prompt.id}>
               <PromptCard

--- a/src/__tests__/PromptCard.test.jsx
+++ b/src/__tests__/PromptCard.test.jsx
@@ -64,12 +64,6 @@ describe('PromptCard Component', () => {
     expect(handlers.onToggleFavorit).toHaveBeenCalledWith(prompt);
   });
 
-  it('calls onColorChange when color circle clicked', () => {
-    const { container } = renderCard();
-    const firstCircle = container.querySelector('.color-circle');
-    fireEvent.click(firstCircle);
-    expect(handlers.onColorChange).toHaveBeenCalledWith('1', 'default');
-  });
 
   it('prompts before archiving the prompt', () => {
     renderCard();

--- a/src/components/PromptCard.css
+++ b/src/components/PromptCard.css
@@ -1,150 +1,93 @@
+.promptcard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  border-radius: 8px;
+  min-width: 280px;
+  background: var(--card-bg, #1E1E22);
+  border: 1px solid var(--card-border, rgba(255,255,255,0.05));
+  box-shadow: 0 2px 8px rgba(0,0,0,.15);
+  color: #fff;
+}
 
-.prompt-card {
-  @apply rounded-xl flex flex-col relative;
-  padding: 20px;
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(8px);
-  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+.light .promptcard {
+  --card-bg: #ffffff;
+  --card-border: rgba(0,0,0,0.05);
+  color: #191919;
+  box-shadow: 0 1px 4px rgba(0,0,0,.10);
+}
+
+.promptcard__title {
+  font-size: 1.05rem;
+  font-weight: 600;
   color: #ffffff;
-  height: 100%;
-  outline: none !important;
-  position: relative;
 }
 
-/* focus reset */
-.prompt-card:focus,
-.prompt-card:focus-within,
-.prompt-card:focus-visible {
-  outline: none !important;
-  box-shadow: none !important;
+.light .promptcard__title {
+  color: #191919;
 }
 
-/* lift on hover */
-.prompt-card:hover {
-  transform: translateY(-8px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+.promptcard__subtitle {
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: #A0A0A5;
 }
 
-/* ---------- outer pulsing border ---------- */
-.prompt-card:hover::after {
-  content: '';
-  position: absolute;
-  top: -5px;
-  left: -5px;
-  right: -5px;
-  bottom: -5px;
-  border: 2px solid #00ffff;
-  border-radius: 10px;
-  animation: pulse-border 2s infinite;
-  pointer-events: none;           
+.light .promptcard__subtitle {
+  color: #6B6B6B;
 }
 
-@keyframes pulse-border {
-  0%, 100% { transform: scale(1);   opacity: 1; }
-  50%      { transform: scale(1.05); opacity: 0.6; }
+.promptcard__badges {
+  display: flex;
+  gap: 0.25rem;
+  margin-top: auto;
 }
 
-.prompt-card {
-  position: relative;
-  overflow: hidden;
-  transition: transform 0.3s ease;
+.badge {
+  padding: 4px 8px;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 500;
+  background: var(--badge-bg, #2b2b2e);
+  color: var(--badge-fg, #ffffff);
 }
 
-.prompt-card::before {
-  content: '';
-  position: absolute;
-  top: 0; left: -100%;
-  width: 200%;
-  height: 100%;
-  background: linear-gradient(
-    120deg,
-    rgba(0,255,200,0.20),
-    rgba(0,150,255,0.20),
-    rgba(0,255,200,0.20)
-  );
-  opacity: 0;
-  transition: opacity 0.5s ease;
-  animation: none;
-  pointer-events: none;      
+.token-count {
+  color: #8BBCEA;
 }
 
-.prompt-card:hover::before {
-  opacity: 1;
-  animation: shine 3.5s forwards;
+.promptcard__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-top: 8px;
 }
 
-@keyframes shine {
-  0%   { transform: translateX(-50%); }
-  50%  { transform: translateX( 50%); }
-  100% { transform: translateX(-50%); }
+.promptcard__actions button {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: transparent;
 }
 
-.prompt-card::before,
-.prompt-card::after {
-  pointer-events: none !important;
+.promptcard__actions button:hover {
+  background: rgba(255,255,255,0.08);
 }
 
-/* ---------- hover icon ---------- */
-.hover-icon {
-  position: absolute;
-  top: 8px; right: 8px;
-  font-size: 20px;
-  opacity: 0;
-  transition: opacity 0.5s ease, transform 0.5s ease;
-  pointer-events: none;
-}
-.prompt-card.hover-enabled:hover .hover-icon {
-  opacity: 1;
-  transform: translateY(-3px);
+.favorite-button {
+  margin-right: auto;
 }
 
-.card-default { background: rgba(49, 51, 56, 0.50); }
-.card-blue    { background: rgba(30, 144, 255, 0.40); }
-.card-green   { background: rgba(50, 205,  50, 0.40); }
-.card-violet  { background: rgba(186, 85, 211, 0.40); }
-
-/* ---------- typography ---------- */
-.prompt-title       { @apply text-xl font-extrabold tracking-wide; font-weight: 800; }
-.prompt-description { @apply italic text-sm line-clamp-2; opacity: 0.8; }
-.prompt-textarea    {
-  @apply w-full rounded-md px-3 py-2 text-sm resize-y min-h-[80px] outline-none;
-  background: transparent; border: none; color: #fff; opacity: 0.9;
-}
-
-/* ---------- tags ---------- */
-.prompt-tags { @apply flex flex-row gap-3 items-center; margin-top: 15px; }
-.category-tag {
-  background: linear-gradient(135deg, #8dd5ff, #5b8cfc);
-  color:#fff; font-weight:700; font-size:0.85rem;
-  padding:4px 14px; border-radius:50px; box-shadow:0 2px 5px rgba(0,0,0,0.2);
-}
-.visibility-tag {
-  font-size:0.75rem; padding:3px 12px; border-radius:50px;
-  display:inline-flex; align-items:center; gap:4px; font-weight:500; color:#fff;
-}
-.visibility-tag.public  { background-color:#4ade80; }
-.visibility-tag.private { background-color:#f87171; }
-.visibility-tag::before { content:'●'; font-size:0.6rem; }
-
-.prompt-actions { @apply flex justify-end gap-2 items-center mt-1; }
-
-.favorite-button { @apply mr-auto text-xl transition-colors cursor-pointer; }
-
-.action-button {
-  @apply rounded-lg px-3 py-1.5 text-sm font-medium text-white transition-transform duration-200;
-  background-color: #1c9887;
-}
-
-.prompt-card .prompt-actions .action-button:hover {
-  transform: translateY(-2px);
-  background-color: #91b75e;
-  box-shadow: 0 6px 15px rgba(0,0,0,0.25),
-              inset 0 1px 2px rgba(255,255,255,0.20);
-}
-
-.prompt-card.archived {
-  opacity: 0.6;
+.promptcard__stripe {
+  width: 100%;
+  height: 4px;
+  margin-top: 12px;
+  border-radius: 0 0 8px 8px;
+  background: var(--stripe-color, #313338);
 }
 
 .archived-badge {
@@ -159,42 +102,39 @@
   pointer-events: none;
 }
 
-.color-selector { @apply flex gap-1 items-center; }
-.color-circle {
-  @apply w-6 h-6 rounded-full cursor-pointer border-2 border-white opacity-80 hover:opacity-100 transition-opacity shadow;
-  position:relative;
-}
-.color-circle::after { content:''; position:absolute; inset:-4px; border-radius:50%; }
-.color-circle.default { background:#313338; }
-.color-circle.blue    { background:#1e90ff; }
-.color-circle.green   { background:#32cd32; }
-.color-circle.violet  { background:#ba55d3; }
-
-/* ---------- copy tooltip ---------- */
-.action-button.copy { position:relative; }
-.action-button.clone { position:relative; }
-.copied-tooltip {
-  position:absolute; top:-35px; left:50%; transform:translateX(-50%);
-  background:#10b981; color:#fff; padding:4px 10px; border-radius:6px;
-  font-size:0.8rem; white-space:nowrap; box-shadow:0 2px 6px rgba(0,0,0,0.25);
-  opacity:0; animation:fadeTooltip 1.5s forwards; pointer-events:none;
-}
-.cloned-tooltip {
-  position:absolute; top:-35px; left:50%; transform:translateX(-50%);
-  background:#10b981; color:#fff; padding:4px 10px; border-radius:6px;
-  font-size:0.8rem; white-space:nowrap; box-shadow:0 2px 6px rgba(0,0,0,0.25);
-  opacity:0; animation:fadeTooltip 1.5s forwards; pointer-events:none;
-}
-@keyframes fadeTooltip {
-  0%{ opacity:0; transform:translate(-50%,-10px); }
-  10%,90%{ opacity:1; transform:translate(-50%,0); }
-  100%{ opacity:0; transform:translate(-50%,-10px); }
-}
-
 .chain-order-badge {
-  position:absolute; top:8px; right:8px; width:28px; height:28px;
-  display:flex; align-items:center; justify-content:center;
-  font-size:0.85rem; font-weight:700;
-  background:rgba(255,255,255,0.16); color:#fff; backdrop-filter:blur(4px);
-  border-radius:6px; box-shadow:0 1px 4px rgba(0,0,0,0.35);
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+  background: rgba(255,255,255,0.16);
+  color: #fff;
+  backdrop-filter: blur(4px);
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.35);
+}
+
+.hover-icon {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  font-size: 20px;
+  opacity: 0;
+  transition: opacity 0.5s ease, transform 0.5s ease;
+  pointer-events: none;
+}
+
+.promptcard.hover-enabled:hover .hover-icon {
+  opacity: 1;
+  transform: translateY(-3px);
+}
+
+.promptcard.archived {
+  opacity: 0.6;
 }

--- a/src/components/PromptCard.jsx
+++ b/src/components/PromptCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { tokensOf } from 'utils/tokenCounter';
 import { useDialog } from 'context/DialogContext';
 import { t } from 'i18n';
@@ -24,20 +24,10 @@ export default function PromptCard({
   const isOwner = prompt.user_id === currentUserId;
   const { showDialog } = useDialog();
 
-  const [color, setColor] = useState(prompt.color || 'default');
   const [copied, setCopied] = useState(false);
   const [cloned, setCloned] = useState(false);
 
-  useEffect(() => {
-    setColor(prompt.color || 'default');
-  }, [prompt.color]);
-
-
-  const handleColorSelect = async (e, clr) => {
-    e.stopPropagation();
-    setColor(clr);
-    await onColorChange?.(prompt.id, clr);
-  };
+  const color = prompt.color || 'default';
 
   const handleCopy = (e) => {
     e.stopPropagation();
@@ -95,8 +85,8 @@ export default function PromptCard({
 
 return (
   <div
-    className={`prompt-card relative ${chainViewActive ? 'chain-view-mode' : ''} ${!chainViewActive ? 'hover-enabled' : ''} ${prompt.archived_at ? 'archived' : ''}`}
-    style={{ background: bgMap[color] }}
+    className={`promptcard relative ${chainViewActive ? 'chain-view-mode' : ''} ${!chainViewActive ? 'hover-enabled' : ''} ${prompt.archived_at ? 'archived' : ''}`}
+    style={{ '--stripe-color': bgMap[color] }}
     tabIndex={-1}
     onFocus={(e) => e.currentTarget.blur()}
   >
@@ -115,9 +105,9 @@ return (
     )}
 
     <header>
-      <h3 className="prompt-title">{prompt.title}</h3>
+      <h3 className="promptcard__title">{prompt.title}</h3>
       {prompt.description && (
-        <p className="prompt-description">{prompt.description}</p>
+        <p className="promptcard__subtitle">{prompt.description}</p>
       )}
     </header>
 
@@ -125,42 +115,30 @@ return (
       <span className="archived-badge">{t('PromptCard.ArchivedBadge')}</span>
     )}
 
-    <div className="prompt-tags mt-auto">
-      <span className="tag category-tag">{prompt.category}</span>
-      <span className={`tag visibility-tag ${prompt.is_public ? 'public' : 'private'}`}>
+    <div className="promptcard__badges mt-auto">
+      <span className="badge category-badge">{prompt.category}</span>
+      <span className={`badge visibility-badge ${prompt.is_public ? 'public' : 'private'}`}> 
         {prompt.is_public ? t('PromptCard.Public') : t('PromptCard.Private')}
       </span>
-      <span className="tag token-tag">
+      <span className="badge token-count">
         {tokenCount} {t('PromptCard.TokensSuffix')}
       </span>
     </div>
 
-    <div className="prompt-actions">
-      <button onClick={handleToggleFavorit} className="favorite-button">
-        {prompt.favorit ? '⭐️' : '☆'}
+    <div className="promptcard__actions">
+      <button onClick={handleToggleFavorit} className="favorite-button" aria-label="Toggle favorite">
+        {prompt.favorit ? '⭐' : '☆'}
       </button>
 
-      <div className="color-selector ml-2">
-        {['default', 'blue', 'green', 'violet'].map(clr => (
-          <button
-            key={clr}
-            type="button"
-            className={`color-circle ${clr}`}
-            onClick={(e) => handleColorSelect(e, clr)}
-            aria-label={`Set ${clr} background`}
-          />
-        ))}
-      </div>
-
-      <button onClick={handleCopy} className="action-button copy relative">
-        {t('PromptCard.Copy')}
+      <button onClick={handleCopy} className="action-button copy" aria-label="Copy prompt">
+        📋
         {copied && (
           <span className="copied-tooltip">{t('PromptCard.Copied')}</span>
         )}
       </button>
 
-      <button onClick={handleClone} className="action-button clone relative">
-        {t('PromptCard.Clone')}
+      <button onClick={handleClone} className="action-button clone" aria-label="Clone prompt">
+        🧬
         {cloned && (
           <span className="cloned-tooltip">{t('PromptCard.Cloned')}</span>
         )}
@@ -191,16 +169,18 @@ return (
       <button
         onClick={(e) => { e.stopPropagation(); isOwner ? onEdit() : onView(prompt); }}
         className="action-button edit"
+        aria-label={isOwner ? 'Edit prompt' : 'View prompt'}
       >
-        {isOwner ? t('PromptCard.Edit') : t('PromptCard.View')}
+        {isOwner ? '✏️' : '👁️'}
       </button>
 
       {isOwner && (
-        <button onClick={handleDelete} className="action-button delete">
-          {t('PromptCard.Delete')}
+        <button onClick={handleDelete} className="action-button delete" aria-label="Delete prompt">
+          🗑️
         </button>
       )}
     </div>
+    <div className="promptcard__stripe" />
   </div>
 );
 }


### PR DESCRIPTION
## Summary
- restyle PromptCard component with cleaner layout
- add minimum width and new colour stripe
- group icon buttons together
- remove colour selector UI
- update grid layout to respect min width
- adjust PromptCard tests

## Testing
- `npm test`
- `npm run lint:strings`


------
https://chatgpt.com/codex/tasks/task_e_686ac161fb9c832cbd3c676a02ae3923